### PR TITLE
Updating to 2018 edition of rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Joshua Smith <anvil775@gmail.com>"]
 name = "maths-traits"
 description = "A simple to use yet abstract system of mathematical traits for the Rust language"
 version = "0.1.3"
+edition = "2018"
 keywords = ["mathematics", "numerics", "algebra", "integer", "real-numbers"]
 categories = ["algorithms", "science", "no-std"]
 repository = "https://github.com/anvil777/maths-traits"

--- a/src/algebra/group_like.rs
+++ b/src/algebra/group_like.rs
@@ -94,9 +94,9 @@ pub mod additive {
     use core::ops::{Mul};
 
     use super::{repeated_doubling, repeated_doubling_neg};
-    use algebra::{Natural, IntegerSubset, Semiring, Ring};
+    use crate::algebra::{Natural, IntegerSubset, Semiring, Ring};
 
-    #[allow(unused_imports)] use algebra::Integer;
+    #[allow(unused_imports)] use crate::algebra::Integer;
 
     ///
     ///A marker trait for stucts whose addition operation is evaluation order independent,
@@ -268,9 +268,9 @@ pub mod multiplicative {
     use num_traits::Pow;
 
     use super::{repeated_squaring, repeated_squaring_inv};
-    use algebra::{Natural, IntegerSubset};
+    use crate::algebra::{Natural, IntegerSubset};
 
-    #[allow(unused_imports)] use algebra::Integer;
+    #[allow(unused_imports)] use crate::algebra::Integer;
 
     ///
     ///A marker trait for stucts whose multiplication operation is evaluation order independent,
@@ -410,7 +410,7 @@ pub mod multiplicative {
 
 }
 
-use algebra::{Natural, IntegerSubset};
+use crate::algebra::{Natural, IntegerSubset};
 
 trait IsZero:Sized { fn _is_zero(&self) -> bool; }
 impl<Z> IsZero for Z { #[inline(always)] default fn _is_zero(&self) -> bool {false} }

--- a/src/algebra/integer.rs
+++ b/src/algebra/integer.rs
@@ -2,8 +2,8 @@
 use core::convert::{TryFrom, TryInto};
 use core::ops::{Rem, RemAssign};
 
-use analysis::ordered::*;
-use algebra::*;
+use crate::analysis::ordered::*;
+use crate::algebra::*;
 
 auto!{
     pub trait CastPrimInt =

--- a/src/algebra/module_like.rs
+++ b/src/algebra/module_like.rs
@@ -1,7 +1,7 @@
 
 pub use core::ops::{Add, AddAssign, Sub, SubAssign, Neg, Mul, MulAssign, Div, DivAssign, Index, IndexMut};
-use analysis::{ComplexRing};
-use algebra::*;
+use crate::analysis::{ComplexRing};
+use crate::algebra::*;
 
 ///
 ///A product between two vectors or module elements resulting in a scalar that is semi-linear in both arguments

--- a/src/algebra/ring_like.rs
+++ b/src/algebra/ring_like.rs
@@ -1,4 +1,4 @@
-use algebra::*;
+use crate::algebra::*;
 
 ///A marker trait for stucts whose multiplication operation preserves addition,
 ///ie `z*(x+y)=z*x+z*y` and `(x+y)*z=x*z+y*z` for all `x`, `y`, and `z`.
@@ -450,7 +450,7 @@ pub fn miller_rabin<Z:Natural>(n:Z) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use algebra::*;
+    use crate::algebra::*;
 
     //TODO: add tests for euclidean and extended_euclidean
 

--- a/src/analysis/metric.rs
+++ b/src/analysis/metric.rs
@@ -1,6 +1,6 @@
 
-use algebra::*;
-use analysis::*;
+use crate::algebra::*;
+use crate::analysis::*;
 
 ///
 ///A real-valued function on a set `X` that quantifies the "distance" between objects

--- a/src/analysis/ordered.rs
+++ b/src/analysis/ordered.rs
@@ -1,5 +1,5 @@
 
-use algebra::*;
+use crate::algebra::*;
 
 ///
 ///A marker trait signifying that for `x > y`, `x+z > x+z` and `z+x > z+x` for all `z`

--- a/src/analysis/real.rs
+++ b/src/analysis/real.rs
@@ -1,6 +1,6 @@
 
-use algebra::*;
-use analysis::*;
+use crate::algebra::*;
+use crate::analysis::*;
 
 ///
 ///Functions and constants for evaluative trigonometric values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,12 +164,7 @@
 #![feature(extra_log_consts)]
 #![recursion_limit="8096"]
 
-#![no_std]
-
-#[cfg(feature = "std")] 
-extern crate std;
-
-extern crate num_traits;
+#![cfg_attr(not(feature = "std"), no_std)]
 
 macro_rules! auto {
 


### PR DESCRIPTION
Changing the edition of rust to 2018 and making necessary changes to `use` statements.
I also removed the now unnecessary `extern crate` statements